### PR TITLE
Feature / [19] Enable teacher navigation to class-subject details page

### DIFF
--- a/pages/subjects/[assignmentId].js
+++ b/pages/subjects/[assignmentId].js
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/router'
+
+const ClassSubjectPage = () => {
+    const router = useRouter()
+    const { subject, class: className } = router.query
+
+    return (
+        <div className="p-6">
+            <h1 className="text-2xl font-bold mb-2">{subject}</h1>
+            <h2 className="text-xl text-gray-700">Class: {className}</h2>
+        </div>
+    )
+}
+
+export default ClassSubjectPage

--- a/pages/subjects/index.js
+++ b/pages/subjects/index.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { getToken, getUserRole, getUserId } from '../../lib/userAuth'
 import { useRouter } from 'next/router'
+import Link from 'next/link'
 
 const SubjectsPage = () => {
     const [subjects, setSubjects] = useState([])
@@ -125,8 +126,17 @@ const SubjectsPage = () => {
                         ) : (
                             teacherSubjects.map((item, idx) => (
                                 <li key={idx} className="border p-3 rounded bg-gray-50">
-                                    <span className="font-medium">{item.subject_name}</span> –{' '}
-                                    <span className="font-medium">{item.class_name}</span>
+                                    <Link
+                                        href={{
+                                            pathname: `/subjects/${item.assignment_id}`,
+                                            query: {
+                                                subject: item.subject_name,
+                                                class: item.class_name
+                                            }
+                                        }}>
+                                        {item.subject_name} – {item.class_name}
+                                    </Link>
+
                                 </li>
                             ))
                         )}


### PR DESCRIPTION
Fixes: https://github.com/smaria03/eduapp_frontend/issues/19

**Changes**
Implemented navigation from the teacher’s subjects list to a dedicated class-subject details page.

**Before**
Teachers could view their assigned subjects and classes, but had no way to access more detailed information.

**After**
Each class-subject pair is now clickable, opening a new page that displays the subject and class name, and prepares for managing grades, attendance, materials, and tests.
<img width="1016" height="396" alt="Screenshot 2025-08-14 at 16 25 05" src="https://github.com/user-attachments/assets/6df343a2-4c29-4c23-bf77-3e1d2575004e" />
