### PR TITLE
Fix / [46] Use endpoint to fetch students without a class (frontend)

### DIFF
--- a/pages/classes/new.js
+++ b/pages/classes/new.js
@@ -9,6 +9,10 @@ const NewClassPage = () => {
     const [students, setStudents] = useState([])
     const [selectedStudentIds, setSelectedStudentIds] = useState([])
     const router = useRouter()
+    const [searchTerm, setSearchTerm] = useState('')
+    const [currentPage, setCurrentPage] = useState(1)
+
+    const STUDENTS_PER_PAGE = 5
 
     useEffect(() => {
         const role = getUserRole()
@@ -56,6 +60,18 @@ const NewClassPage = () => {
         }
     }
 
+    const filteredStudents = students.filter(student =>
+        student.name.toLowerCase().includes(searchTerm.toLowerCase())
+    )
+
+    const totalPages = Math.ceil(filteredStudents.length / STUDENTS_PER_PAGE)
+
+    const paginatedStudents = filteredStudents.slice(
+        (currentPage - 1) * STUDENTS_PER_PAGE,
+        currentPage * STUDENTS_PER_PAGE
+    )
+
+
     return (
         <div className="p-8 max-w-md mx-auto">
             <h1 className="text-2xl font-bold mb-4">Create a New Class</h1>
@@ -73,11 +89,21 @@ const NewClassPage = () => {
                 />
                 <div>
                     <p className="font-medium mb-2">Add students to this class:</p>
+                    <input
+                        type="text"
+                        value={searchTerm}
+                        onChange={e => {
+                            setSearchTerm(e.target.value)
+                            setCurrentPage(1)
+                        }}
+                        placeholder="Search student by name"
+                        className="w-full border px-3 py-2 rounded mb-2"
+                    />
                     <div className="max-h-48 overflow-y-auto border p-2 rounded space-y-1">
-                        {students.length === 0 ? (
-                            <p className="text-gray-500 text-sm italic">No students available</p>
+                        {paginatedStudents.length === 0 ? (
+                            <p className="text-gray-500 text-sm italic">No students match your search</p>
                         ) : (
-                            students.map(student => (
+                            paginatedStudents.map(student => (
                                 <label key={student.id} className="block">
                                     <input
                                         type="checkbox"
@@ -97,6 +123,25 @@ const NewClassPage = () => {
                                 </label>
                             ))
                         )}
+                    </div>
+                    <div className="flex justify-between items-center mt-2 text-sm">
+                        <button
+                            type="button"
+                            disabled={currentPage === 1}
+                            onClick={() => setCurrentPage(p => p - 1)}
+                            className="px-2 py-1 border rounded disabled:opacity-50"
+                        >
+                            Prev
+                        </button>
+                        <span>Page {currentPage} of {totalPages}</span>
+                        <button
+                            type="button"
+                            disabled={currentPage === totalPages}
+                            onClick={() => setCurrentPage(p => p + 1)}
+                            className="px-2 py-1 border rounded disabled:opacity-50"
+                        >
+                            Next
+                        </button>
                     </div>
                 </div>
                 <button

--- a/pages/classes/new.js
+++ b/pages/classes/new.js
@@ -17,14 +17,13 @@ const NewClassPage = () => {
         }
 
         const fetchStudents = async () => {
-            const res = await fetch('http://localhost:3000/api/students', {
+            const res = await fetch('http://localhost:3000/api/students/without_class', {
                 method: 'GET',
                 headers: {
                     Authorization: `Bearer ${getToken()}`
                 }
             })
-            const data = await res.json()
-            const withoutClass = data.filter(s => s.school_class_id === null)
+            const withoutClass = await res.json()
             setStudents(withoutClass)
         }
 


### PR DESCRIPTION
Fixes: https://github.com/smaria03/eduapp_backend/issues/46

Backend PR: https://github.com/smaria03/eduapp_backend/pull/47

**Changes**
Switched to using the new /api/students/without_class endpoint to correctly display all students without a class when creating a new class. This ensures the full list is fetched from the backend, avoiding issues caused by pagination.

**Before**
<img width="458" height="293" alt="Create a New Class" src="https://github.com/user-attachments/assets/46a3d872-45b9-4121-829a-0f23ee898b20" />

**After**
<img width="450" height="481" alt="Screenshot 2025-08-19 at 14 01 33" src="https://github.com/user-attachments/assets/81a78d5a-cb13-4473-8a74-28bd0dcbd75b" />
