### PR TITLE
Fix / [25] Show class name instead of teacher name in teacher timetable view

### DIFF
--- a/pages/timetable/index.js
+++ b/pages/timetable/index.js
@@ -196,7 +196,9 @@ const TimetablePage = () => {
                                             <div className="flex flex-col gap-2">
                                                 <div className="text-sm">
                                                     <div className="font-semibold">{e.subject_name || '—'}</div>
-                                                    <div className="text-gray-600">{e.teacher_name || '—'}</div>
+                                                    <div className="text-gray-600">
+                                                        {mode === 'class' ? e.teacher_name || '—' : e.class_name || '—'}
+                                                    </div>
                                                 </div>
                                                 <div>
                                                     <button


### PR DESCRIPTION
Fixes: https://github.com/smaria03/eduapp_frontend/issues/25

**Changes**
Updated the timetable view so that when in "By teacher" mode, the class name is displayed instead of the teacher's name.

**Before**
<img width="1125" height="581" alt="Screenshot 2025-08-19 at 15 24 13" src="https://github.com/user-attachments/assets/8be1cda1-4b2e-4cdf-91da-a99a40409147" />


**After**
<img width="1125" height="592" alt="Screenshot 2025-08-19 at 15 23 19" src="https://github.com/user-attachments/assets/4b2f7033-a3ce-405a-b53a-cb84516e824d" />
